### PR TITLE
fix typo in `./docs/md/account/blog.md`

### DIFF
--- a/docs/md/account/blog.md
+++ b/docs/md/account/blog.md
@@ -86,7 +86,7 @@
 > > > >
 > > > > Keep this URL safe! If other people gain access to it, they will be able to publish your blog
 > > > > without you realizing it, which might result in unfinished content being published. If you think
-> > > > your publish webhook have been compormised, simply use the refresh button ([refresh](:Icon (align=middle))) to
+> > > > your publish webhook have been compromised, simply use the refresh button ([refresh](:Icon (align=middle))) to
 > > > > create a new webhook, invalidating the old one.
 > > >
 > > > > [bug_report](:Icon) **TROUBLESHOOTING**


### PR DESCRIPTION
noticed a typo, forked and fixed it.
The typo was:
You typed `compormised` instead of `compromised` which is a typo here. I noticed it and gave a fix here. Is this good?